### PR TITLE
Provide CST installation via GitHub/Jitpack using Gradle, Maven, etc.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @rgudwin
+
+/src/br/unicamp/cst/consciousness/ @andre-paraense @rgudwin
+
+/src/br/unicamp/cst/core/ @andre-paraense @rgudwin
+
+/src/br/unicamp/cst/motivational/ @eduardofroes @rgudwin

--- a/README.md
+++ b/README.md
@@ -3,53 +3,57 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e9d016cbb9689600abb7/test_coverage)](https://codeclimate.com/github/CST-Group/cst/test_coverage)
 
 # Welcome to the CST Toolkit pages.
+
 The [CST Toolkit](http://cst.fee.unicamp.br) is a Java-based toolkit to allow the construction of Cognitive Architectures. It has been developed at the [University of Campinas](http://www.dca.fee.unicamp.br) by a group of researchers in the field of Cognitive Architectures leaded by Prof. [Ricardo Gudwin](http://faculty.dca.fee.unicamp.br/gudwin). 
 
 Note: This library is still under development, and some concepts or features might not be available yet. [Feedback/bug report](https://github.com/CST-Group/cst/issues) and [Pull Requests](https://github.com/CST-Group/cst/pulls) are most welcome!
 
 ## Installation
 
-#### Gradle
+### Gradle
 
 - Step 1. Add the JitPack repository to your build file. Add it in your root build.gradle at the end of repositories:
 
-
-	repositories {
+```
+repositories {
 			...
 			maven { url 'https://jitpack.io' }
-	}
-
+}
+```
 
 - Step 2. Add the dependency
 
-
+```
 	dependencies {
             ...
             implementation 'com.github.CST-Group:cst:0.2.3'
 	}
+```
 
-
-#### Maven
+### Maven
 
 - Step 1. Add the JitPack repository to your build file.
 
+```
 	<repositories>
 		<repository>
 		    <id>jitpack.io</id>
 		    <url>https://jitpack.io</url>
 		</repository>
 	</repositories>
+```
 
 - Step 2. Add the dependency
 
+```
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>cst</artifactId>
 	    <version>0.2.3</version>
 	</dependency>
+```
 
-
-#### Manual
+### Manual
 
 Download the latest [release](https://github.com/CST-Group/cst/releases) and set it as a dependency in your project.
 

--- a/README.md
+++ b/README.md
@@ -11,47 +11,43 @@ Note: This library is still under development, and some concepts or features mig
 
 #### Gradle
 
-- Step 1. Add the JitPack repository to your build file.
+- Step 1. Add the JitPack repository to your build file. Add it in your root build.gradle at the end of repositories:
 
-Add it in your root build.gradle at the end of repositories:
 
-`
-repositories {
+	repositories {
 			...
 			maven { url 'https://jitpack.io' }
-}
-`
+	}
+
 
 - Step 2. Add the dependency
 
-`
-dependencies {
+
+	dependencies {
             ...
             implementation 'com.github.CST-Group:cst:0.2.3'
-}
-`
+	}
+
 
 #### Maven
 
 - Step 1. Add the JitPack repository to your build file.
 
-`
-<repositories>
+	<repositories>
 		<repository>
 		    <id>jitpack.io</id>
 		    <url>https://jitpack.io</url>
 		</repository>
-</repositories>
-`
+	</repositories>
 
 - Step 2. Add the dependency
-`
-<dependency>
+
+	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>cst</artifactId>
 	    <version>0.2.3</version>
-</dependency>
-`
+	</dependency>
+
 
 #### Manual
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,60 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/e9d016cbb9689600abb7/maintainability)](https://codeclimate.com/github/CST-Group/cst/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e9d016cbb9689600abb7/test_coverage)](https://codeclimate.com/github/CST-Group/cst/test_coverage)
 
-## Welcome to the CST Toolkit pages.
+# Welcome to the CST Toolkit pages.
 The [CST Toolkit](http://cst.fee.unicamp.br) is a Java-based toolkit to allow the construction of Cognitive Architectures. It has been developed at the [University of Campinas](http://www.dca.fee.unicamp.br) by a group of researchers in the field of Cognitive Architectures leaded by Prof. [Ricardo Gudwin](http://faculty.dca.fee.unicamp.br/gudwin). 
 
 Note: This library is still under development, and some concepts or features might not be available yet. [Feedback/bug report](https://github.com/CST-Group/cst/issues) and [Pull Requests](https://github.com/CST-Group/cst/pulls) are most welcome!
 
 ## Installation
 
-Download the latest [release](https://github.com/CST-Group/cst/releases) and set it as a dependency in your project. (soon to be available in a repository such as MavenCentral).
+#### Gradle
+
+- Step 1. Add the JitPack repository to your build file.
+
+Add it in your root build.gradle at the end of repositories:
+
+`
+repositories {
+			...
+			maven { url 'https://jitpack.io' }
+}
+`
+
+- Step 2. Add the dependency
+
+`
+dependencies {
+            ...
+            implementation 'com.github.CST-Group:cst:0.2.3'
+}
+`
+
+#### Maven
+
+- Step 1. Add the JitPack repository to your build file.
+
+`
+<repositories>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+</repositories>
+`
+
+- Step 2. Add the dependency
+`
+<dependency>
+	    <groupId>com.github.CST-Group</groupId>
+	    <artifactId>cst</artifactId>
+	    <version>0.2.3</version>
+</dependency>
+`
+
+#### Manual
+
+Download the latest [release](https://github.com/CST-Group/cst/releases) and set it as a dependency in your project.
 
 ## Building the source code
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Note: This library is still under development, and some concepts or features mig
 - Step 1. Add the JitPack repository to your build file. Add it in your root build.gradle at the end of repositories:
 
 ```
-repositories {
+	repositories {
 			...
 			maven { url 'https://jitpack.io' }
-}
+	}
 ```
 
 - Step 2. Add the dependency

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,6 @@ dependencies {
 }
 
 jar {
-    from javadoc
-    from sourceSets.main.allSource
     from {
     	configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
     }
@@ -82,10 +80,16 @@ jar {
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc
+    from {
+    	configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource
+    from {
+    	configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }
 artifacts
 {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
    extraLibs name: 'jsoar-debugger'
    configurations.implementation.extendsFrom(configurations.extraLibs)
    
+   api 'com.google.code.gson:gson:2.7'
+   
    implementation group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
    implementation group: 'org.json', name: 'json', version: '20160212'
    implementation group: 'net.sf.jung', name: 'jung-algorithms', version: '2.0.1'
@@ -47,8 +49,7 @@ dependencies {
    implementation group: 'junit', name: 'junit', version: '4.9'
    implementation group: 'org.opt4j', name: 'opt4j-core', version: '3.1'
    implementation group: 'org.opt4j', name: 'opt4j-optimizers', version: '3.1'
-   implementation group: 'org.opt4j', name: 'opt4j-viewer', version: '3.1'
-   api 'com.google.code.gson:gson:2.7'
+   implementation group: 'org.opt4j', name: 'opt4j-viewer', version: '3.1' 
    implementation 'org.antlr:antlr4-runtime:4.5.3'
    implementation 'org.slf4j:slf4j-api:1.7.5'
    implementation 'net.openhft:compiler:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
    implementation group: 'org.opt4j', name: 'opt4j-core', version: '3.1'
    implementation group: 'org.opt4j', name: 'opt4j-optimizers', version: '3.1'
    implementation group: 'org.opt4j', name: 'opt4j-viewer', version: '3.1'
-   implementation 'com.google.code.gson:gson:2.7'
+   api 'com.google.code.gson:gson:2.7'
    implementation 'org.antlr:antlr4-runtime:4.5.3'
    implementation 'org.slf4j:slf4j-api:1.7.5'
    implementation 'net.openhft:compiler:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,21 @@ targetCompatibility = 1.8
 version = '0.2.3'
 
 repositories {
+	flatDir {
+        dirs 'libs'
+    }
     mavenCentral()
 }
 
-dependencies {
-   api fileTree(dir: 'libs', include: ['*.jar'])
+configurations {
+    extraLibs
+}
 
+dependencies {
+   extraLibs name:'jsoar-core'
+   extraLibs name: 'jsoar-debugger'
+   configurations.implementation.extendsFrom(configurations.extraLibs)
+   
    implementation group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
    implementation group: 'org.json', name: 'json', version: '20160212'
    implementation group: 'net.sf.jung', name: 'jung-algorithms', version: '2.0.1'
@@ -61,6 +70,13 @@ dependencies {
    implementation 'org.apache.commons:commons-math3:3.0'
 }
 
+jar {
+    from javadoc
+    from sourceSets.main.allSource
+    from {
+    	configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
 
 task javadocJar(type: Jar) {
     classifier = 'javadoc'

--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,18 @@ sourceSets {
    }
 }
 
+description = "CST is the Cognitive Systems Toolkit, a toolkit for the construction of Cognitive Systems and Cognitive Architectures"
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.2.2'
+version = '0.2.3'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-   implementation fileTree(dir: 'libs', include: ['*.jar'])
+   api fileTree(dir: 'libs', include: ['*.jar'])
 
    implementation group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
    implementation group: 'org.json', name: 'json', version: '20160212'
@@ -41,26 +43,37 @@ dependencies {
    implementation 'org.antlr:antlr4-runtime:4.5.3'
    implementation 'org.slf4j:slf4j-api:1.7.5'
    implementation 'net.openhft:compiler:2.3.0'
-   implementation 'ch.qos.logback:logback-classic:1.0.11'
-    
-   runtimeOnly group: 'aopalliance', name: 'aopalliance', version: '1.0'
-   runtimeOnly group: 'asm', name: 'asm', version: '3.1'
-   runtimeOnly group: 'org.sonatype.sisu.inject', name: 'cglib', version: '2.2.1-v20090111'
-   runtimeOnly group: 'com.google.inject', name: 'guice', version: '3.0'
-   runtimeOnly group: 'com.google.inject.extensions', name: 'guice-multibindings', version: '3.0'
-   runtimeOnly group: 'javax.inject', name: 'javax.inject', version: '1'
-   runtimeOnly group: 'net.sf.jung', name: 'jung-api', version: '2.0.1'
-   runtimeOnly group: 'org.opt4j', name: 'opt4j-benchmarks', version: '3.1'
-   runtimeOnly group: 'org.opt4j', name: 'opt4j-operators', version: '3.1'
-   runtimeOnly group: 'org.opt4j', name: 'opt4j-satdecoding', version: '3.1'
-   runtimeOnly group: 'org.opt4j', name: 'opt4j-tutorial', version: '3.1'
-   runtimeOnly group: 'org.ow2.sat4j', name: 'org.ow2.sat4j.core', version: '2.3.3'
-   runtimeOnly 'com.google.collections:google-collections:1.0'
-   runtimeOnly 'commons-beanutils:commons-beanutils-core:1.8.0'
-   runtimeOnly 'org.apache.commons:commons-math3:3.0'
+   implementation 'ch.qos.logback:logback-classic:1.0.11' 
+   implementation group: 'aopalliance', name: 'aopalliance', version: '1.0'
+   implementation group: 'asm', name: 'asm', version: '3.1'
+   implementation group: 'org.sonatype.sisu.inject', name: 'cglib', version: '2.2.1-v20090111'
+   implementation group: 'com.google.inject', name: 'guice', version: '3.0'
+   implementation group: 'com.google.inject.extensions', name: 'guice-multibindings', version: '3.0'
+   implementation group: 'javax.inject', name: 'javax.inject', version: '1'
+   implementation group: 'net.sf.jung', name: 'jung-api', version: '2.0.1'
+   implementation group: 'org.opt4j', name: 'opt4j-benchmarks', version: '3.1'
+   implementation group: 'org.opt4j', name: 'opt4j-operators', version: '3.1'
+   implementation group: 'org.opt4j', name: 'opt4j-satdecoding', version: '3.1'
+   implementation group: 'org.opt4j', name: 'opt4j-tutorial', version: '3.1'
+   implementation group: 'org.ow2.sat4j', name: 'org.ow2.sat4j.core', version: '2.3.3'
+   implementation 'com.google.collections:google-collections:1.0'
+   implementation 'commons-beanutils:commons-beanutils-core:1.8.0'
+   implementation 'org.apache.commons:commons-math3:3.0'
 }
 
 
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+artifacts
+{
+    archives javadocJar, sourcesJar
+}
 
 jacocoTestReport {
     reports {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
    configurations.implementation.extendsFrom(configurations.extraLibs)
    
    api 'com.google.code.gson:gson:2.7'
+   api 'org.slf4j:slf4j-api:1.7.5'
+   api 'net.openhft:compiler:2.3.0'
    
    implementation group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
    implementation group: 'org.json', name: 'json', version: '20160212'
@@ -51,8 +53,6 @@ dependencies {
    implementation group: 'org.opt4j', name: 'opt4j-optimizers', version: '3.1'
    implementation group: 'org.opt4j', name: 'opt4j-viewer', version: '3.1' 
    implementation 'org.antlr:antlr4-runtime:4.5.3'
-   implementation 'org.slf4j:slf4j-api:1.7.5'
-   implementation 'net.openhft:compiler:2.3.0'
    implementation 'ch.qos.logback:logback-classic:1.0.11' 
    implementation group: 'aopalliance', name: 'aopalliance', version: '1.0'
    implementation group: 'asm', name: 'asm', version: '3.1'


### PR DESCRIPTION
### Preface

This is the final PR of a sequence of PRs aimed at implementing CI/CD in this repository. If you have not seen the ones before, you should study them in order to be able to better understand the context. They were in cronological order:
1. [Migrate to Gradle nature project and get dependency libs from maven](https://github.com/CST-Group/cst/pull/2)
2. [Travis integration for CI/CD](https://github.com/CST-Group/cst/pull/4)  

### Why was it necessary?

The main objective of this PR was to make it easier for CST users to install it as a dependency in their projects, without having to carry all libs and classpath configurations, more aligned with current build tools (such as Gradle and Maven). This PR achieves it in a very succint way. After integrating this PR, any CST user will be able to install it with two simple steps, as exemplified below for Gradle and Maven build tools (it is still possible to add it manually):

#### Gradle

- Step 1. Add the JitPack repository to your build file. Add it in your root build.gradle at the end of repositories:

```
	repositories {
			...
			maven { url 'https://jitpack.io' }
	}
```

- Step 2. Add the dependency

```
	dependencies {
            ...
            implementation 'com.github.CST-Group:cst:0.2.3'
	}
```

The format is `com.github.CST-Group:cst:Tag`

#### Maven

- Step 1. Add the JitPack repository to your build file.

```
	<repositories>
		<repository>
		    <id>jitpack.io</id>
		    <url>https://jitpack.io</url>
		</repository>
	</repositories>
```

- Step 2. Add the dependency

```
	<dependency>
	    <groupId>com.github.CST-Group</groupId>
	    <artifactId>cst</artifactId>
	    <version>0.2.3</version>
	</dependency>
```

The format is `<version>Tag</version>`

#### Manual

Of course it is still possible to download the latest [release](https://github.com/CST-Group/cst/releases) and set it as a dependency in their project.

### How was it done?

Basically, this PR promoted changes in the `build.gradle` of this repository in order to implement a correct packaging of libs so the recipient could receive all content necessary, including Javadoc and Source Code of the CST library imported as a dependency. You will notice that only 2 files where changed: `build.gradle` and `README.md`, the latter one being modified to account for explaining how to easily include CST as a dependency from now on. 

But wait, is that all? 

If you are into the context of this change, you will remember that we had planned to implement an automatic way of deploying the package to MavenCentral. Yes, it would have been a hell of work, having to implement scripts that would automatically sign the packages with GPG keys, configure sonarcloud repos, scripts to automatically upload, etc. But then, there were these new initiatives to keep the package and the code in the same place to save us! In this case, we are relying on [Jitpack](https://jitpack.io/) to simply package our releases from GitHub and include as dependencies in the projects that will use CST. Later on, we can move to other services, such as the one [GitHub itself is developing (click for details)](https://github.com/features/package-registry). But for now, I see no reason to change, Jitpack just works!

### Implementation details

After have being graced by Jitpack, all that was left was to correctly package everything in `build.gradle`: 

- We had to guarantee that CST would carry the local `libs/` folder jsoar`.jar`s with it. For that, we manually changed the `jar` gradle task to include these extra libs (`extraLibs` configuration) in order to make a fat .jar with CST + JSOAR jars only. The rest of the libs will follow transitively. Just to be clear, this was necessary as JSOAR Jars are not provided in Maven or any other repository that we know.
- Studying SonarCloud requirements for open source projects, I found out one important aspect is to include the `source` code and the `javadoc` inside open source projects packages, so users will have a good level of quality and enlightement when consuming the library classes and methods. If you check the changes in `build.gradle`, you will notice we have new tasks to include Javadoc and Source Code in the package, more towards the end of the file.
- Remember we were confused about how to distinguish between `api` and `implementation` in the dependencies? As soon as we added the `javadoc` task, it became apparent in practice which libs should be `api`, as they were failing to pass the `javadoc`, exactly because they were being mentioned publicly in method and classes, therefore subject to `javadoc`, but where not present in the package, because were marked as `implementation` instead of `api`. So we can say it was pretty much trial and error, which is fair, because now we are 100% sure which should go as `api`.
- The libs marked before as `runtimeOnly` had to be marked `implementation`, otherwise they would not follow transitively to the projects importing CST. This was pretty much trial and error too.

These are all the main changes!

### How to test?

Go ahead and import CST directly as explained before in any new project or in any project you use it already. In this second case, remember to get rid of any `libs/` folder you had to carry, any classpath config, etc. Freedom!

OBS: as you have to test before this PR is merged and version `0.2.3`is launched, of course you will now be able to import using this tag. The good news is that you can use the last commit hash of this branch as the tag to import! So test it this way (for Gradle):

```
	dependencies {
            ...
            implementation 'com.github.CST-Group:cst:b9e9f984cef1374207c369fed66fc539b477824e'
	}
```

Do not forget Step 1 before that!

### Future works

This is the end in the implementation of the CI/CD pipeline! Uhuuuuu!!!
