### PR TITLE
Small patch to Jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://travis-ci.org/CST-Group/cst.svg?branch=master)](https://travis-ci.org/CST-Group/cst)
 [![Maintainability](https://api.codeclimate.com/v1/badges/e9d016cbb9689600abb7/maintainability)](https://codeclimate.com/github/CST-Group/cst/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e9d016cbb9689600abb7/test_coverage)](https://codeclimate.com/github/CST-Group/cst/test_coverage)
+[![](https://jitpack.io/v/CST-Group/cst.svg?label=Release)](https://jitpack.io/#CST-Group/cst)
+
 
 # Welcome to the CST Toolkit pages.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:cst:0.2.3'
+            implementation 'com.github.CST-Group:cst:0.2.4'
 	}
 ```
 
@@ -51,7 +51,7 @@ Note: This library is still under development, and some concepts or features mig
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>cst</artifactId>
-	    <version>0.2.3</version>
+	    <version>0.2.4</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 plugins {
 	id 'java-library-distribution'
   	id 'jacoco'
+  	id 'maven'
 }
+
+group = 'com.github.CST-Group'
 
 sourceSets {
    main {
@@ -21,7 +24,7 @@ description = "CST is the Cognitive Systems Toolkit, a toolkit for the construct
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.2.3'
+version = '0.2.4'
 
 repositories {
 	flatDir {


### PR DESCRIPTION
### Why was it necessary?
According to [Jitpack docs](https://jitpack.io/docs/BUILDING/), it is important to have the `maven` plugin in the `build.gradle`.

### How was it done?

Added the `maven` plugin in the `build.gradle` and also the `group` tag, as specified in the docs.

### How to test?

Import CST library as in the `README` docs!
