### PR TITLE
Rosservice bind bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:cst:0.3.0'
+            implementation 'com.github.CST-Group:cst:0.3.1'
 	}
 ```
 
@@ -53,7 +53,7 @@ Sometimes, the version number (tag) in this README gets out of date, as maintain
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>cst</artifactId>
-	    <version>0.3.0</version>
+	    <version>0.3.1</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "CST is the Cognitive Systems Toolkit, a toolkit for the construct
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.3.0'
+version = '0.3.1'
 
 repositories {
 	flatDir {

--- a/src/main/java/br/unicamp/cst/bindings/rosjava/RosServiceClientCodelet.java
+++ b/src/main/java/br/unicamp/cst/bindings/rosjava/RosServiceClientCodelet.java
@@ -6,7 +6,6 @@ package br.unicamp.cst.bindings.rosjava;
 import java.net.URI;
 
 import org.ros.exception.RemoteException;
-import org.ros.exception.RosRuntimeException;
 import org.ros.exception.ServiceNotFoundException;
 import org.ros.namespace.GraphName;
 import org.ros.node.ConnectedNode;
@@ -34,23 +33,25 @@ import br.unicamp.cst.core.exceptions.CodeletActivationBoundsException;
  * @param <T> Service Message Response - Ex: AddTwonIntsResponse from ROS Tutorials
  */
 public abstract class RosServiceClientCodelet<S,T> extends Codelet implements NodeMain {
-	
+
 	protected String nodeName;
-	
+
 	protected String service;
-	
+
 	protected String messageServiceType;
-	
+
 	protected Memory motorMemory;
-	
+
 	protected S serviceMessageRequest;
-	
+
 	protected ServiceClient<S, T> serviceClient;
-	
+
 	protected NodeMainExecutor nodeMainExecutor;
-	
+
 	protected NodeConfiguration nodeConfiguration;
 	
+	protected ServiceResponseListener<T> serviceResponseListener;
+
 	/**
 	 * Constructor for the RosServiceClientCodelet.
 	 * 
@@ -68,27 +69,42 @@ public abstract class RosServiceClientCodelet<S,T> extends Codelet implements No
 		this.messageServiceType = messageServiceType;
 		setName(nodeName);
 		
+		serviceResponseListener = new ServiceResponseListener<T>() {
+			@Override
+			public void onSuccess(T response) {			    	  
+				if(response != null) {
+					processServiceResponse(response);
+					motorMemory.setI(null);
+				}						
+			}
+
+			@Override
+			public void onFailure(RemoteException e) {
+				e.printStackTrace();
+			}
+		};
+
 		nodeMainExecutor = DefaultNodeMainExecutor.newDefault();
 		nodeConfiguration = NodeConfiguration.newPublic(host,masterURI);
 	}
-	
+
 	@Override
 	public synchronized void start() {
 		startRosNode();
 		super.start();
 	}
-	
+
 	@Override
 	public synchronized void stop() {
-		
+
 		stopRosNode();
 		super.stop();
 	}
-	
+
 	private void startRosNode() {
 		nodeMainExecutor.execute(this, nodeConfiguration);
 	}
-	
+
 	private void stopRosNode() {
 		nodeMainExecutor.shutdownNodeMain(this);
 	}
@@ -119,39 +135,26 @@ public abstract class RosServiceClientCodelet<S,T> extends Codelet implements No
 			}
 		}
 	}
-	
+
 	/**
 	 * Prepare the service request to be sent, formatting it with the contents of the motor memory.
 	 * @param motorMemory the memory with the content to be formatted in the form of a service request.
 	 * @param serviceMessageRequest the service message request to be sent.
 	 */
 	public abstract void formatServiceRequest(Memory motorMemory, S serviceMessageRequest);
-	
+
 	private void callService() {
 		if(serviceClient != null && serviceMessageRequest != null) {
-		    serviceClient.call(serviceMessageRequest, new ServiceResponseListener<T>() {
-			      @Override
-			      public void onSuccess(T response) {			    	  
-			    	  if(response != null) {
-			    		  processServiceResponse(response);
-			    		  motorMemory.setI(null);
-			    	  }						
-			      }
-
-			      @Override
-			      public void onFailure(RemoteException e) {
-			        throw new RosRuntimeException(e);
-			      }
-			    });		   
+			serviceClient.call(serviceMessageRequest, serviceResponseListener);		   
 		}
 	}
-	
+
 	/**
 	 * Processes the service response in a free way.
 	 * @param serviceMessageResponse the response after the service has been executed.
 	 */
 	public abstract void processServiceResponse(T serviceMessageResponse);
-	
+
 	@Override
 	public GraphName getDefaultNodeName() {
 		return GraphName.of(nodeName);
@@ -159,12 +162,12 @@ public abstract class RosServiceClientCodelet<S,T> extends Codelet implements No
 
 	@Override
 	public void onStart(ConnectedNode connectedNode) {	    
-	    try {
-	      serviceClient = connectedNode.newServiceClient(service, messageServiceType);
-	    } catch (ServiceNotFoundException e) {
-	      throw new RosRuntimeException(e);
-	    }
-	    serviceMessageRequest = serviceClient.newMessage();
+		try {
+			serviceClient = connectedNode.newServiceClient(service, messageServiceType);
+		} catch (ServiceNotFoundException e) {
+			e.printStackTrace();
+		}
+		serviceMessageRequest = serviceClient.newMessage();
 	}
 
 	@Override
@@ -176,7 +179,7 @@ public abstract class RosServiceClientCodelet<S,T> extends Codelet implements No
 	public void onShutdownComplete(Node node) {
 		// empty
 	}
-	
+
 	@Override
 	public void onError(Node node, Throwable throwable) {
 		// empty

--- a/src/main/java/br/unicamp/cst/bindings/rosjava/RosServiceClientCodelet.java
+++ b/src/main/java/br/unicamp/cst/bindings/rosjava/RosServiceClientCodelet.java
@@ -75,6 +75,8 @@ public abstract class RosServiceClientCodelet<S,T> extends Codelet implements No
 				if(response != null) {
 					processServiceResponse(response);
 					motorMemory.setI(null);
+					stopRosNode();
+					startRosNode();
 				}						
 			}
 

--- a/src/test/java/br/unicamp/cst/bindings/rosjava/RosJavaTest.java
+++ b/src/test/java/br/unicamp/cst/bindings/rosjava/RosJavaTest.java
@@ -112,4 +112,61 @@ public class RosJavaTest {
 		
 		mind.shutDown();
     }
+    
+    @Test
+    public void testRosServiceCalledTwice() throws URISyntaxException {
+    	
+    	AddTwoIntService addTwoIntService = new AddTwoIntService();
+		NodeMainExecutor nodeMainExecutor = DefaultNodeMainExecutor.newDefault();
+		NodeConfiguration nodeConfiguration = NodeConfiguration.newPublic("127.0.0.1",new URI("http://127.0.0.1:11311"));
+		nodeMainExecutor.execute(addTwoIntService, nodeConfiguration);
+				
+		try {
+			Thread.sleep(2000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
+		Mind mind = new Mind();
+		
+		AddTwoIntServiceClient addTwoIntServiceClient = new AddTwoIntServiceClient("127.0.0.1",new URI("http://127.0.0.1:11311"));
+		
+		MemoryObject motorMemory = mind.createMemoryObject(addTwoIntServiceClient.getName());
+		addTwoIntServiceClient.addInput(motorMemory);
+		
+		Integer expectedSum = 5;
+		
+		Integer[] numsToSum = new Integer[] {2,3};
+		motorMemory.setI(numsToSum);	
+		
+		mind.insertCodelet(addTwoIntServiceClient);
+		
+		mind.start();
+		
+		try {
+			Thread.sleep(2000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
+		assertEquals(expectedSum, addTwoIntServiceClient.getSum());
+		
+		expectedSum = 6;
+		
+		numsToSum = new Integer[] {3,3};
+		motorMemory.setI(numsToSum);
+		
+		try {
+			Thread.sleep(2000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
+		assertEquals(expectedSum, addTwoIntServiceClient.getSum());
+		
+		nodeMainExecutor.shutdownNodeMain(addTwoIntService);
+		
+		mind.shutDown();
+    	
+    }
 }


### PR DESCRIPTION
### Why was it necessary?

This PR was necessary because the RosService binding codelet was not capable of calling the service more than once, mainly because the communication channel is closed.

### How was it done?

We stop and start the ROS Node inside the codelet now on.

### How to test?

You can just run the unit test that was implemented or implement your own codelet that calls a service twice.

### Future works

No more in this direction for now.
