### PR TITLE
Improving the disconnected Codelet message to cite Codelet's name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "CST is the Cognitive Systems Toolkit, a toolkit for the construct
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.6.0'
+version = '0.6.1'
 
 repositories {
 	flatDir {

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -760,8 +760,8 @@ public abstract class Codelet implements Runnable {
 					if (activation >= threshold)
 						proc();
 				} else {
-					System.out.println("This codelet thread could not find a memory object it needs (Class):"
-							+ this.getClass().getCanonicalName());
+					System.out.println("This Codelet could not find a memory object it needs: "
+							+ Codelet.this.name);
 				}
 
 				enable_count = 0;

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -760,7 +760,7 @@ public abstract class Codelet implements Runnable {
 					if (activation >= threshold)
 						proc();
 				} else {
-					System.out.println("This Codelet could not find a memory object it needs: "
+					throw new Exception("This Codelet could not find a memory object it needs: "
 							+ Codelet.this.name);
 				}
 

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -20,6 +20,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import br.unicamp.cst.core.exceptions.CodeletActivationBoundsException;
 import br.unicamp.cst.core.exceptions.CodeletThresholdBoundsException;
+import br.unicamp.cst.core.exceptions.MemoryObjectNotFoundException;
 import br.unicamp.cst.util.ExecutionTimeWriter;
 import br.unicamp.cst.util.ProfileInfo;
 
@@ -760,7 +761,7 @@ public abstract class Codelet implements Runnable {
 					if (activation >= threshold)
 						proc();
 				} else {
-					throw new Exception("This Codelet could not find a memory object it needs: "
+					throw new MemoryObjectNotFoundException("This Codelet could not find a memory object it needs: "
 							+ Codelet.this.name);
 				}
 

--- a/src/main/java/br/unicamp/cst/core/exceptions/MemoryObjectNotFoundException.java
+++ b/src/main/java/br/unicamp/cst/core/exceptions/MemoryObjectNotFoundException.java
@@ -1,0 +1,58 @@
+/**
+ * 
+ */
+package br.unicamp.cst.core.exceptions;
+
+/**
+ * This class represents a Java exception to be thrown when the access memory object
+ * method is not capable of finding the corresponding memory object
+ * 
+ * @author andre
+ *
+ */
+public class MemoryObjectNotFoundException extends Exception {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -6845401281653737754L;
+
+	/**
+	 * 
+	 */
+	public MemoryObjectNotFoundException() {
+	}
+
+	/**
+	 * @param message
+	 */
+	public MemoryObjectNotFoundException(String message) {
+		super(message);
+	}
+
+	/**
+	 * @param cause
+	 */
+	public MemoryObjectNotFoundException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 */
+	public MemoryObjectNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 * @param enableSuppression
+	 * @param writableStackTrace
+	 */
+	public MemoryObjectNotFoundException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/test/java/br/unicamp/cst/core/entities/DisconnectedCodeletTest.java
+++ b/src/test/java/br/unicamp/cst/core/entities/DisconnectedCodeletTest.java
@@ -1,0 +1,42 @@
+/**
+ * 
+ */
+package br.unicamp.cst.core.entities;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author andre
+ *
+ */
+public class DisconnectedCodeletTest {
+	
+	@Test
+	public void testDisconnectedCodelet() {
+		
+		Codelet disconnectedCodelet = new Codelet() {
+				
+			@Override
+			public void accessMemoryObjects() {
+			}
+			
+			@Override
+			public void proc() {
+								
+			}
+			
+			@Override
+			public void calculateActivation() {
+								
+			}
+		};
+		disconnectedCodelet.setName("Disconnected Codelet");
+		disconnectedCodelet.start();
+		
+	
+		assertEquals(null, disconnectedCodelet.getInput("TYPE", 0));
+	}
+
+}

--- a/src/test/java/br/unicamp/cst/core/entities/DisconnectedCodeletTest.java
+++ b/src/test/java/br/unicamp/cst/core/entities/DisconnectedCodeletTest.java
@@ -35,8 +35,11 @@ public class DisconnectedCodeletTest {
 		disconnectedCodelet.setName("Disconnected Codelet");
 		disconnectedCodelet.start();
 		
-	
-		assertEquals(null, disconnectedCodelet.getInput("TYPE", 0));
+		try {
+			disconnectedCodelet.getInput("TYPE", 0);
+		}catch(Exception e) {
+			assertEquals(e.getMessage(), "This Codelet could not find a memory object it needs: Disconnected Codelet");
+		}		
 	}
 
 }


### PR DESCRIPTION
### Why was it necessary?

We needed to improve the message of the exception raised when a codelet cannot find the memory objects it is connected to, in order to more easily find bugs in application.

### How was it done?

We started printing the name to the Codelet in the message.

### How to test?

A test was implemented. Just run `src/test/java/br/unicamp/cst/core/entities/DisconnectedCodeletTest.java`to see it working.