### PR TITLE
Memory observers

### DIFF
--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -772,8 +772,8 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	/**
 	 * Sets this Codelet to be a memory observer.
 	 * 
-	 * @param loop
-	 *            the loop to set
+	 * @param isMemoryObserver
+	 *            the isMemoryObserver to set
 	 */
 	public synchronized void setIsMemoryObserver(boolean isMemoryObserver) {
 		this.isMemoryObserver = isMemoryObserver;
@@ -811,6 +811,9 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 							+ Codelet.this.name);
         }
         
+        /**
+         *  runs when codelet is a memory observer and memory input changes
+         */
         @Override
     	public void notifyCodelet() {
     		long startTime = 0l;

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -340,6 +340,9 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 *            one input to set.
 	 */
 	public synchronized void addInput(Memory input) {
+		if (isMemoryObserver) {
+			input.addMemoryObservers(this);
+		}
 		this.inputs.add(input);
 	}
 
@@ -350,6 +353,11 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 *            a list of inputs.
 	 */
 	public synchronized void addInputs(List<Memory> inputs) {
+		if (isMemoryObserver) {
+		    for (Memory memory : inputs) {
+		    	memory.addMemoryObservers(this);
+			}
+		}
 		this.inputs.addAll(inputs);
 	}
 
@@ -514,6 +522,9 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 *            one broadcast input to set.
 	 */
 	public synchronized void addBroadcast(Memory b) {
+		if (isMemoryObserver) {
+			b.addMemoryObservers(this);
+		}
 		this.broadcast.add(b);
 	}
 
@@ -524,6 +535,11 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 *            one input to set.
 	 */
 	public synchronized void addBroadcasts(List<Memory> broadcast) {
+		if (isMemoryObserver) {
+			for (Memory memory : broadcast) {
+				memory.addMemoryObservers(this);
+			}
+		}
 		this.broadcast.addAll(broadcast);
 	}
 

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -341,7 +341,7 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 */
 	public synchronized void addInput(Memory input) {
 		if (isMemoryObserver) {
-			input.addMemoryObservers(this);
+			input.addMemoryObserver(this);
 		}
 		this.inputs.add(input);
 	}
@@ -355,7 +355,7 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	public synchronized void addInputs(List<Memory> inputs) {
 		if (isMemoryObserver) {
 		    for (Memory memory : inputs) {
-		    	memory.addMemoryObservers(this);
+		    	memory.addMemoryObserver(this);
 			}
 		}
 		this.inputs.addAll(inputs);
@@ -523,7 +523,7 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	 */
 	public synchronized void addBroadcast(Memory b) {
 		if (isMemoryObserver) {
-			b.addMemoryObservers(this);
+			b.addMemoryObserver(this);
 		}
 		this.broadcast.add(b);
 	}
@@ -537,7 +537,7 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	public synchronized void addBroadcasts(List<Memory> broadcast) {
 		if (isMemoryObserver) {
 			for (Memory memory : broadcast) {
-				memory.addMemoryObservers(this);
+				memory.addMemoryObserver(this);
 			}
 		}
 		this.broadcast.addAll(broadcast);

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -816,8 +816,6 @@ public abstract class Codelet implements Runnable, MemoryObserver {
                                      
                                     raiseException();
                                    
-//    				throw new MemoryObjectNotFoundException("This Codelet could not find a memory object it needs: "
-//    						+ Codelet.this.name);
     			}
 
     			enable_count = 0;
@@ -882,8 +880,6 @@ public abstract class Codelet implements Runnable, MemoryObserver {
                                      
                                     raiseException();
                                    
-//					throw new MemoryObjectNotFoundException("This Codelet could not find a memory object it needs: "
-//							+ Codelet.this.name);
 				}
 
 				enable_count = 0;

--- a/src/main/java/br/unicamp/cst/core/entities/Codelet.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Codelet.java
@@ -79,7 +79,10 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 
 	/** defines if proc() should be automatically called in a loop */
 	protected boolean loop = true; //
-
+	
+	/** defines if codelet is a memory observer (runs when memory input changes) */
+	protected boolean isMemoryObserver = false; //
+	
 	/**
 	 * If the proc() method is set to be called automatically in a loop, this
 	 * variable stores the time step for such a loop. A timeStep of value 0
@@ -751,6 +754,16 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 	}
 	
 	/**
+	 * Sets this Codelet to be a memory observer.
+	 * 
+	 * @param loop
+	 *            the loop to set
+	 */
+	public synchronized void setIsMemoryObserver(boolean isMemoryObserver) {
+		this.isMemoryObserver = isMemoryObserver;
+	}
+	
+	/**
 	 * Sets Codelet Profiler
 	 * 
 	 * @param filePath 
@@ -815,8 +828,6 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 
     		} finally {
 
-    			//if (shouldLoop()) 
-    				//timer.schedule(new CodeletTimerTask(), timeStep);
     			if (Codelet.this.codeletProfiler != null) {
     				Codelet.this.codeletProfiler.profile(Codelet.this);
     			}
@@ -852,8 +863,6 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 		@Override
 		public synchronized void run() {
 			
-			System.out.println(">>>>>>>>>>>>> CodeletTimerTask run - codelet " + name);
-
 			long startTime = 0l;
 			long endTime = 0l;
 			long duration = 0l;
@@ -885,8 +894,7 @@ public abstract class Codelet implements Runnable, MemoryObserver {
 
 			} finally {
 
-				System.out.println("    ===== shouldLoop() " + shouldLoop());
-				if (shouldLoop()) 
+				if (!isMemoryObserver && shouldLoop()) 
 					timer.schedule(new CodeletTimerTask(), timeStep);
 				if (Codelet.this.codeletProfiler != null) {
 					Codelet.this.codeletProfiler.profile(Codelet.this);

--- a/src/main/java/br/unicamp/cst/core/entities/Memory.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Memory.java
@@ -79,5 +79,11 @@ public interface Memory {
 	 */
 	public Long getTimestamp();
 	
+	/**
+	 * Add a memory observer to its list
+	 * @param memoryObserver
+	 */
+	public void addMemoryObservers(MemoryObserver memoryObserver);
+	
 
 }

--- a/src/main/java/br/unicamp/cst/core/entities/Memory.java
+++ b/src/main/java/br/unicamp/cst/core/entities/Memory.java
@@ -83,7 +83,7 @@ public interface Memory {
 	 * Add a memory observer to its list
 	 * @param memoryObserver
 	 */
-	public void addMemoryObservers(MemoryObserver memoryObserver);
+	public void addMemoryObserver(MemoryObserver memoryObserver);
 	
 
 }

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
@@ -478,9 +478,9 @@ public class MemoryContainer implements Memory {
 	}
 
 	@Override
-	public void addMemoryObservers(MemoryObserver memoryObserver) {
+	public void addMemoryObserver(MemoryObserver memoryObserver) {
 		for (Memory memory : memories) {
-			memory.addMemoryObservers(memoryObserver);
+			memory.addMemoryObserver(memoryObserver);
 		}
 
 	}

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
@@ -53,8 +53,7 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Creates a MemoryContainer.
 	 * 
-	 * @param type
-	 *            the type of the memories inside the container.
+	 * @param type the type of the memories inside the container.
 	 */
 	public MemoryContainer(String type) {
 
@@ -66,8 +65,7 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Sets the type of the memories inside the container.
 	 * 
-	 * @param name
-	 *            the type of the memories inside the container.
+	 * @param name the type of the memories inside the container.
 	 */
 	public synchronized void setType(String name) {
 		this.name = name;
@@ -103,8 +101,7 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Gets the info of the memory which has the index passed.
 	 * 
-	 * @param index
-	 *            the index of the memory whose info is searched.
+	 * @param index the index of the memory whose info is searched.
 	 * @return the info of the memory which has the index passe or null is not
 	 *         found.
 	 */
@@ -118,26 +115,26 @@ public class MemoryContainer implements Memory {
 			return (null);
 		}
 	}
-        
-        /**
+
+	/**
 	 * Gets the info of the memory which has the name passed.
 	 * 
 	 * @param name the name of the memory whose info is searched.
-	 * @return the info of the memory which has the name passed 
-         *          or null if it is not found.
+	 * @return the info of the memory which has the name passed or null if it is not
+	 *         found.
 	 */
 	public synchronized Object getI(String name) {
-            for (Memory m : memories) {
-                if (m.getName().equals(name)) return(m.getI());
-            }
-            return(null);
+		for (Memory m : memories) {
+			if (m.getName().equals(name))
+				return (m.getI());
+		}
+		return (null);
 	}
 
 	/**
 	 * Gets the info of the memory filtered by the predicate.
 	 * 
-	 * @param predicate
-	 *            the predicate to be used to filter the stream.
+	 * @param predicate the predicate to be used to filter the stream.
 	 * @return the info of the memory or null if not found.
 	 */
 	public synchronized Object getI(Predicate<Memory> predicate) {
@@ -164,8 +161,7 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Gets the info of the memory reduced by the binary operator passed.
 	 * 
-	 * @param accumulator
-	 *            the binary operator.
+	 * @param accumulator the binary operator.
 	 * @return the info of the memory or null if not found.
 	 */
 	public synchronized Object getI(BinaryOperator<Memory> accumulator) {
@@ -190,8 +186,7 @@ public class MemoryContainer implements Memory {
 	}
 
 	/**
-	 * MemoryContainer inserts the info as a new MemoryObject in its Memory
-	 * list.
+	 * MemoryContainer inserts the info as a new MemoryObject in its Memory list.
 	 */
 	@Override
 	public synchronized int setI(Object info) {
@@ -201,10 +196,8 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Creates a Memory Object with the info and the evaluation passed.
 	 * 
-	 * @param info
-	 *            the info of the new Memory Object.
-	 * @param evaluation
-	 *            the evaluation of the new Memory Object.
+	 * @param info       the info of the new Memory Object.
+	 * @param evaluation the evaluation of the new Memory Object.
 	 * @return the index of the new Memory Object.
 	 */
 	public synchronized int setI(Object info, Double evaluation) {
@@ -224,10 +217,8 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Sets the info of the Memory with the index passed.
 	 * 
-	 * @param info
-	 *            the information to be set in the
-	 * @param index
-	 *            the index of the memory inside the container.
+	 * @param info  the information to be set in the
+	 * @param index the index of the memory inside the container.
 	 */
 	public synchronized void setI(Object info, int index) {
 
@@ -248,15 +239,12 @@ public class MemoryContainer implements Memory {
 	}
 
 	/**
-	 * Sets the info and the evaluation of the memory with the index passed
-	 * inside this container.
+	 * Sets the info and the evaluation of the memory with the index passed inside
+	 * this container.
 	 * 
-	 * @param info
-	 *            the information to be set in the.
-	 * @param index
-	 *            the index of the memory inside this container.
-	 * @param evaluation
-	 *            the evaluation to be set.
+	 * @param info       the information to be set in the.
+	 * @param index      the index of the memory inside this container.
+	 * @param evaluation the evaluation to be set.
 	 */
 	public synchronized void setI(Object info, Double evaluation, int index) {
 
@@ -276,17 +264,14 @@ public class MemoryContainer implements Memory {
 		}
 
 	}
-        
-        /**
-	 * Sets the info as the info and an evaluation passed to a Memory of the
-	 * type passed.
+
+	/**
+	 * Sets the info as the info and an evaluation passed to a Memory of the type
+	 * passed.
 	 * 
-	 * @param info
-	 *            the info.
-	 * @param evaluation
-	 *            the evaluation to set.
-	 * @param type
-	 *            the type of the Memory
+	 * @param info       the info.
+	 * @param evaluation the evaluation to set.
+	 * @param type       the type of the Memory
 	 * @return the index of the memory
 	 */
 	public synchronized int setI(Object info, double evaluation, String type) {
@@ -363,10 +348,8 @@ public class MemoryContainer implements Memory {
 	 * Sets the evaluation of the memory with the index passed inside this
 	 * container.
 	 * 
-	 * @param eval
-	 *            the evaluation to set.
-	 * @param index
-	 *            the index of the memory inside this container.
+	 * @param eval  the evaluation to set.
+	 * @param index the index of the memory inside this container.
 	 */
 	public synchronized void setEvaluation(Double eval, int index) {
 
@@ -394,8 +377,7 @@ public class MemoryContainer implements Memory {
 	/**
 	 * Adds a memory to this container.
 	 * 
-	 * @param memory
-	 *            the memory to be added in this container
+	 * @param memory the memory to be added in this container
 	 */
 	public synchronized int add(Memory memory) {
 
@@ -454,8 +436,6 @@ public class MemoryContainer implements Memory {
 //		return index;
 //	}
 
-	
-
 	/**
 	 * Gets all the memories inside this container.
 	 * 
@@ -464,36 +444,45 @@ public class MemoryContainer implements Memory {
 	public synchronized ArrayList<Memory> getAllMemories() {
 		return memories;
 	}
-        
-        /**
+
+	/**
 	 * Gets the internal memory which has the name passed.
 	 * 
 	 * @param name the name of the memory whose info is searched.
-	 * @return the memory which has the name passed 
-         *          or null if it is not found.
+	 * @return the memory which has the name passed or null if it is not found.
 	 */
 	public synchronized Memory getInternalMemory(String name) {
-            for (Memory m : memories) {
-                if (m.getName().equals(name)) return(m);
-            }
-            return(null);
-	}
-        
-        /**
-         * Get the TimeStamp of the internal Memory which has the greatest evaluation.
-         * @return 
-         */
-        public synchronized Long getTimestamp() {
-            double maxEval = 0.0d;
-            Long timestamp = null;
-            for (Memory memory : memories) {
-		double memoryEval = memory.getEvaluation();
-		if (memoryEval >= maxEval) {
-                    maxEval = memoryEval;
-                    timestamp = memory.getTimestamp();
+		for (Memory m : memories) {
+			if (m.getName().equals(name))
+				return (m);
 		}
-            }
-            return timestamp;
+		return (null);
+	}
+
+	/**
+	 * Get the TimeStamp of the internal Memory which has the greatest evaluation.
+	 * 
+	 * @return
+	 */
+	public synchronized Long getTimestamp() {
+		double maxEval = 0.0d;
+		Long timestamp = null;
+		for (Memory memory : memories) {
+			double memoryEval = memory.getEvaluation();
+			if (memoryEval >= maxEval) {
+				maxEval = memoryEval;
+				timestamp = memory.getTimestamp();
+			}
+		}
+		return timestamp;
+	}
+
+	@Override
+	public void addMemoryObservers(MemoryObserver memoryObserver) {
+		for (Memory memory : memories) {
+			memory.addMemoryObservers(memoryObserver);
+		}
+
 	}
 
 }

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
@@ -13,8 +13,10 @@ package br.unicamp.cst.core.entities;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A Memory Object is a generic information holder, acting as a sign or an
@@ -68,7 +70,7 @@ public class MemoryObject implements Memory, Serializable {
 	/**
 	 * List of codetlets that observes memory
 	 */
-	private List<MemoryObserver> memoryObservers;
+	private Set<MemoryObserver> memoryObservers;
 
 	/**
 	 * Creates a MemoryObject.
@@ -260,7 +262,7 @@ public class MemoryObject implements Memory, Serializable {
 	 */
 	public void addMemoryObservers(MemoryObserver memoryObserver) {
 		if (this.memoryObservers == null) {
-			this.memoryObservers = new ArrayList<MemoryObserver>(); 
+			this.memoryObservers = new HashSet<MemoryObserver>(); 
 		}
 		this.memoryObservers.add(memoryObserver);
 	}

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
@@ -260,7 +260,7 @@ public class MemoryObject implements Memory, Serializable {
 	 * Add a memory observer to its list
 	 * @param memoryObserver
 	 */
-	public void addMemoryObservers(MemoryObserver memoryObserver) {
+	public void addMemoryObserver(MemoryObserver memoryObserver) {
 		if (this.memoryObservers == null) {
 			this.memoryObservers = new HashSet<MemoryObserver>(); 
 		}

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryObject.java
@@ -12,6 +12,9 @@
 package br.unicamp.cst.core.entities;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * A Memory Object is a generic information holder, acting as a sign or an
@@ -61,6 +64,11 @@ public class MemoryObject implements Memory, Serializable {
 	 * Type of the memory object
 	 */
 	private String name;
+	
+	/**
+	 * List of codetlets that observes memory
+	 */
+	private List<MemoryObserver> memoryObservers;
 
 	/**
 	 * Creates a MemoryObject.
@@ -106,8 +114,17 @@ public class MemoryObject implements Memory, Serializable {
 	public synchronized int setI(Object info) {
 		this.I = info;
 		setTimestamp(System.currentTimeMillis());
+		notifyMemoryObservers();
 
 		return -1;
+	}
+	
+	private synchronized void notifyMemoryObservers() {
+		if (memoryObservers != null && !memoryObservers.isEmpty()) {
+			for (MemoryObserver memoryObserver : memoryObservers) {
+				memoryObserver.notifyCodelet();
+			}
+		}
 	}
 
 	/**
@@ -235,5 +252,16 @@ public class MemoryObject implements Memory, Serializable {
 		} else if (!timestamp.equals(other.timestamp))
 			return false;
 		return true;
+	}
+
+	/**
+	 * Add a memory observer to its list
+	 * @param memoryObserver
+	 */
+	public void addMemoryObservers(MemoryObserver memoryObserver) {
+		if (this.memoryObservers == null) {
+			this.memoryObservers = new ArrayList<MemoryObserver>(); 
+		}
+		this.memoryObservers.add(memoryObserver);
 	}
 }

--- a/src/main/java/br/unicamp/cst/core/entities/MemoryObserver.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryObserver.java
@@ -1,0 +1,6 @@
+package br.unicamp.cst.core.entities;
+
+public interface MemoryObserver {
+	public void notifyCodelet();
+
+}

--- a/src/test/java/br/unicamp/cst/core/entities/MemoryTest.java
+++ b/src/test/java/br/unicamp/cst/core/entities/MemoryTest.java
@@ -55,7 +55,7 @@ public class MemoryTest {
         }
 
 		@Override
-		public void addMemoryObservers(MemoryObserver memoryObserver) {
+		public void addMemoryObserver(MemoryObserver memoryObserver) {
 			// TODO Auto-generated method stub
 			
 		}

--- a/src/test/java/br/unicamp/cst/core/entities/MemoryTest.java
+++ b/src/test/java/br/unicamp/cst/core/entities/MemoryTest.java
@@ -53,6 +53,12 @@ public class MemoryTest {
         public Long getTimestamp() {
             return this.timestamp;
         }
+
+		@Override
+		public void addMemoryObservers(MemoryObserver memoryObserver) {
+			// TODO Auto-generated method stub
+			
+		}
     };
 
     @Test

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -249,15 +249,17 @@ public class TestMemoryObserver {
 		c2.addBroadcasts(broadcasts);
 		m.insertCodelet(c2);
 		m.start();
-		mo.setI(10);
-		mo.setI(4);
-		m2.setI(1);
-		m4.setI(2);
+		for (int i = 0; i < 60; i++) {
+			mo.setI(i);
+			mo.setI(i);
+			m2.setI(i);
+			m4.setI(i);
+		}
 		Thread.sleep(2000);
 		m.shutDown();
 
-		assertEquals(5, c.getCounter());
-		assertEquals(2, c2.getCounter());
+		assertEquals(241, c.getCounter());
+		assertEquals(61, c2.getCounter());
 		assertTrue(c2.isProfiling());
 	}
 }

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -239,8 +239,10 @@ public class TestMemoryObserver {
 		c2.addInputs(memories);
 		c2.addOutput(m6);
 		c2.addOutput(m3);
-		c2.addBroadcast(m5);
-		c2.addBroadcast(m5);
+		ArrayList<Memory> broadcasts = new ArrayList<Memory>();
+		broadcasts.add(m5);
+		broadcasts.add(m5);
+		c2.addBroadcasts(broadcasts);
 		m.insertCodelet(c2);
 		m.start();
 		mo.setI(10);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -9,50 +9,188 @@ import br.unicamp.cst.core.entities.MemoryContainer;
 import br.unicamp.cst.core.entities.MemoryObject;
 import br.unicamp.cst.core.entities.Mind;
 
+class CodeletToTest extends Codelet {
+
+	private int counter = 0;
+
+	public int getCounter() {
+		return counter;
+	}
+
+	public CodeletToTest(String name) {
+		setName(name);
+	}
+
+	@Override
+	public void accessMemoryObjects() {
+
+	}
+
+	@Override
+	public void calculateActivation() {
+
+	}
+
+	@Override
+	public void proc() {
+		counter++;
+	}
+
+}
+
 public class TestMemoryObserver {
 
 	@Test
-	public void test() throws InterruptedException {
-		// Codelet runs being a Memory Observer, in this case memory info does not change, so codelet wont run
-				Mind m = new Mind();
-		        MemoryObject m1 = m.createMemoryObject("M1", 0.12);
-		        MemoryObject m2 = m.createMemoryObject("M2", 0.32);
-		        MemoryObject m3 = m.createMemoryObject("M3", 0.44);
-		        MemoryObject m4 = m.createMemoryObject("M4", 0.52);
-		        MemoryObject m5 = m.createMemoryObject("M5", 0.12);
-		        MemoryContainer m6 = m.createMemoryContainer("C1");
-		        MemoryContainer m7 = m.createMemoryContainer("C2");
-		        TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
-		        mComplex.complextest = new TestComplexMemoryObjectInfo();
-		        for (int i=0;i<3;i++)
-		       	 mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
-		        MemoryObject mo = new MemoryObject();
-		        mo.setType("TestObject");
-		        mo.setI(mComplex);
-		        m7.setI(0.55, 0.23);
-		        m6.setI(0.33, 0.22);
-		        m6.setI(0.12, 0.13);
-		        m6.setI(m7);
-		        Codelet c = new TestCodelet("Codelet 1");
-		        c.setLoop(false);
-		        c.addInput(m1);
-		        c.addInput(m2);
-		        c.addOutput(m3);
-		        c.addOutput(m4);
-		        c.addBroadcast(m5);
-		        c.addBroadcast(mo);
-		        m.insertCodelet(c);
-		        Codelet c2 = new TestCodelet("Codelet 2");
-		        c2.setLoop(false);
-		        c2.addInput(m4);
-		        c2.addInput(m5);
-		        c2.addOutput(m6);
-		        c2.addOutput(m3);
-		        c2.addBroadcast(m5);
-		        m.insertCodelet(c2);
-		        m.start();
-		        Thread.sleep(2000);
-		        m.shutDown();
+	public void test1() throws InterruptedException {
+		// Codelet runs being a Memory Observer, in this case memory info does not
+		// change, so codelet wont run
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		CodeletToTest c = new CodeletToTest("Codelet 1");
+		c.setIsMemoryObserver(true);
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		mo.addMemoryObservers(c);
+		m.insertCodelet(c);
+		CodeletToTest c2 = new CodeletToTest("Codelet 2");
+		c2.setIsMemoryObserver(true);
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		mo.addMemoryObservers(c);
+		m.insertCodelet(c2);
+		m.start();
+		Thread.sleep(2000);
+		m.shutDown();
+
+		assertEquals(1, c.getCounter());
+		assertEquals(1, c2.getCounter());
 	}
 
+	@Test
+	public void test2() throws InterruptedException {
+		// Codelet runs being a Memory Observer, and memories inputs are changed
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		CodeletToTest c = new CodeletToTest("Codelet 1");
+		c.setIsMemoryObserver(true);
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		mo.addMemoryObservers(c);
+		m.insertCodelet(c);
+		CodeletToTest c2 = new CodeletToTest("Codelet 2");
+		c2.setIsMemoryObserver(true);
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		mo.addMemoryObservers(c2);
+		m.insertCodelet(c2);
+		m.start();
+		mo.setI(10);
+		Thread.sleep(2000);
+		m.shutDown();
+
+		assertEquals(2, c.getCounter());
+		assertEquals(2, c2.getCounter());
+	}
+	
+	@Test
+	public void test3() throws InterruptedException {
+		// Codelet runs being a Memory Observer, and memories inputs are changed
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		CodeletToTest c = new CodeletToTest("Codelet 1");
+		c.setIsMemoryObserver(true);
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		mo.addMemoryObservers(c);
+		m2.addMemoryObservers(c);
+		m4.addMemoryObservers(c);
+		m.insertCodelet(c);
+		CodeletToTest c2 = new CodeletToTest("Codelet 2");
+		c2.setIsMemoryObserver(true);
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		m.insertCodelet(c2);
+		m.start();
+		mo.setI(10);
+		mo.setI(4);
+		m2.setI(1);
+		m4.setI(2);
+		Thread.sleep(2000);
+		m.shutDown();
+
+		assertEquals(5, c.getCounter());
+		assertEquals(1, c2.getCounter());
+	}
 }

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -150,7 +150,7 @@ public class TestMemoryObserver {
 	}
 	
 	@Test
-	public void test3() throws InterruptedException {
+	public void multipleMemoryChangesTest() throws InterruptedException {
 		// Codelet runs being a Memory Observer, and memories inputs are changed
 		Mind m = new Mind();
 		MemoryObject m1 = m.createMemoryObject("M1", 0.12);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -235,6 +235,7 @@ public class TestMemoryObserver {
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
+		c2.setProfiling(true);
 		ArrayList<Memory> memories = new ArrayList<Memory>();
 		memories.add(m4);
 		memories.add(m4);
@@ -257,5 +258,6 @@ public class TestMemoryObserver {
 
 		assertEquals(5, c.getCounter());
 		assertEquals(2, c2.getCounter());
+		assertTrue(c2.isProfiling());
 	}
 }

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -6,8 +6,6 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
-import com.sun.tools.javac.util.List;
-
 import br.unicamp.cst.core.entities.Codelet;
 import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.entities.MemoryContainer;

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -125,19 +125,22 @@ public class TestMemoryObserver {
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
 		c2.addInput(m4);
+		c2.addInput(m7);
 		c2.addInput(m5);
 		c2.addOutput(m6);
 		c2.addOutput(m3);
 		c2.addBroadcast(m5);
 		mo.addMemoryObservers(c2);
+		m7.addMemoryObservers(c2);
 		m.insertCodelet(c2);
 		m.start();
 		mo.setI(10);
+		m7.setI(100, 0);
 		Thread.sleep(2000);
 		m.shutDown();
 
 		assertEquals(2, c.getCounter());
-		assertEquals(2, c2.getCounter());
+		assertEquals(3, c2.getCounter());
 	}
 	
 	@Test
@@ -191,6 +194,58 @@ public class TestMemoryObserver {
 		m.shutDown();
 
 		assertEquals(5, c.getCounter());
-		assertEquals(1, c2.getCounter());
+		assertEquals(2, c2.getCounter());
+	}
+	
+	@Test
+	public void test4() throws InterruptedException {
+		// Codelet runs being a Memory Observer, and memories inputs are changed, add same memory more than once
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		CodeletToTest c = new CodeletToTest("Codelet 1");
+		c.setIsMemoryObserver(true);
+		mo.addMemoryObservers(c);
+		mo.addMemoryObservers(c);
+		m2.addMemoryObservers(c);
+		m2.addMemoryObservers(c);
+		m4.addMemoryObservers(c);
+		m.insertCodelet(c);
+		CodeletToTest c2 = new CodeletToTest("Codelet 2");
+		c2.setIsMemoryObserver(true);
+		c2.addInput(m4);
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		c2.addBroadcast(m5);
+		m.insertCodelet(c2);
+		m.start();
+		mo.setI(10);
+		mo.setI(4);
+		m2.setI(1);
+		m4.setI(2);
+		Thread.sleep(2000);
+		m.shutDown();
+
+		assertEquals(5, c.getCounter());
+		assertEquals(2, c2.getCounter());
 	}
 }

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -104,6 +104,9 @@ public class TestMemoryObserver {
 		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
 		MemoryContainer m6 = m.createMemoryContainer("C1");
 		MemoryContainer m7 = m.createMemoryContainer("C2");
+		MemoryContainer m8 = m.createMemoryContainer("C3");
+		m7.add(m4);
+		m8.add(m7);
 		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
 		mComplex.complextest = new TestComplexMemoryObjectInfo();
 		for (int i = 0; i < 3; i++)
@@ -134,11 +137,11 @@ public class TestMemoryObserver {
 		c2.addOutput(m3);
 		c2.addBroadcast(m5);
 		mo.addMemoryObservers(c2);
-		m7.addMemoryObservers(c2);
+		m8.addMemoryObservers(c2);
 		m.insertCodelet(c2);
 		m.start();
 		mo.setI(10);
-		m7.setI(100, 0);
+		m8.setI(100, 0);
 		Thread.sleep(2000);
 		m.shutDown();
 

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -44,7 +44,7 @@ class CodeletToTest extends Codelet {
 public class TestMemoryObserver {
 
 	@Test
-	public void test1() throws InterruptedException {
+	public void noMemoryChangeTest() throws InterruptedException {
 		// Codelet runs being a Memory Observer, in this case memory info does not
 		// change, so codelet wont run
 		Mind m = new Mind();

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -94,7 +94,7 @@ public class TestMemoryObserver {
 	}
 
 	@Test
-	public void test2() throws InterruptedException {
+	public void usualRunTest() throws InterruptedException {
 		// Codelet runs being a Memory Observer, and memories inputs are changed
 		Mind m = new Mind();
 		MemoryObject m1 = m.createMemoryObject("M1", 0.12);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -2,9 +2,14 @@ package br.unicamp.cst.util;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+
 import org.junit.Test;
 
+import com.sun.tools.javac.util.List;
+
 import br.unicamp.cst.core.entities.Codelet;
+import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.entities.MemoryContainer;
 import br.unicamp.cst.core.entities.MemoryObject;
 import br.unicamp.cst.core.entities.Mind;
@@ -229,9 +234,11 @@ public class TestMemoryObserver {
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
-		c2.addInput(m4);
-		c2.addInput(m4);
-		c2.addInput(m5);
+		ArrayList<Memory> memories = new ArrayList<Memory>();
+		memories.add(m4);
+		memories.add(m4);
+		memories.add(m5);
+		c2.addInputs(memories);
 		c2.addOutput(m6);
 		c2.addOutput(m3);
 		c2.addBroadcast(m5);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -204,7 +204,7 @@ public class TestMemoryObserver {
 	}
 	
 	@Test
-	public void test4() throws InterruptedException {
+	public void addSameMemoryTest() throws InterruptedException {
 		// Codelet runs being a Memory Observer, and memories inputs are changed, add same memory more than once
 		Mind m = new Mind();
 		MemoryObject m1 = m.createMemoryObject("M1", 0.12);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -74,7 +74,7 @@ public class TestMemoryObserver {
 		c.addOutput(m4);
 		c.addBroadcast(m5);
 		c.addBroadcast(mo);
-		mo.addMemoryObservers(c);
+		mo.addMemoryObserver(c);
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
@@ -83,7 +83,7 @@ public class TestMemoryObserver {
 		c2.addOutput(m6);
 		c2.addOutput(m3);
 		c2.addBroadcast(m5);
-		mo.addMemoryObservers(c);
+		mo.addMemoryObserver(c);
 		m.insertCodelet(c2);
 		m.start();
 		Thread.sleep(2000);
@@ -126,7 +126,7 @@ public class TestMemoryObserver {
 		c.addOutput(m4);
 		c.addBroadcast(m5);
 		c.addBroadcast(mo);
-		mo.addMemoryObservers(c);
+		mo.addMemoryObserver(c);
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
@@ -136,8 +136,8 @@ public class TestMemoryObserver {
 		c2.addOutput(m6);
 		c2.addOutput(m3);
 		c2.addBroadcast(m5);
-		mo.addMemoryObservers(c2);
-		m8.addMemoryObservers(c2);
+		mo.addMemoryObserver(c2);
+		m8.addMemoryObserver(c2);
 		m.insertCodelet(c2);
 		m.start();
 		mo.setI(10);
@@ -179,9 +179,9 @@ public class TestMemoryObserver {
 		c.addOutput(m4);
 		c.addBroadcast(m5);
 		c.addBroadcast(mo);
-		mo.addMemoryObservers(c);
-		m2.addMemoryObservers(c);
-		m4.addMemoryObservers(c);
+		mo.addMemoryObserver(c);
+		m2.addMemoryObserver(c);
+		m4.addMemoryObserver(c);
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);
@@ -227,11 +227,11 @@ public class TestMemoryObserver {
 		m6.setI(m7);
 		CodeletToTest c = new CodeletToTest("Codelet 1");
 		c.setIsMemoryObserver(true);
-		mo.addMemoryObservers(c);
-		mo.addMemoryObservers(c);
-		m2.addMemoryObservers(c);
-		m2.addMemoryObservers(c);
-		m4.addMemoryObservers(c);
+		mo.addMemoryObserver(c);
+		mo.addMemoryObserver(c);
+		m2.addMemoryObserver(c);
+		m2.addMemoryObserver(c);
+		m4.addMemoryObserver(c);
 		m.insertCodelet(c);
 		CodeletToTest c2 = new CodeletToTest("Codelet 2");
 		c2.setIsMemoryObserver(true);

--- a/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
+++ b/src/test/java/br/unicamp/cst/util/TestMemoryObserver.java
@@ -1,0 +1,58 @@
+package br.unicamp.cst.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import br.unicamp.cst.core.entities.Codelet;
+import br.unicamp.cst.core.entities.MemoryContainer;
+import br.unicamp.cst.core.entities.MemoryObject;
+import br.unicamp.cst.core.entities.Mind;
+
+public class TestMemoryObserver {
+
+	@Test
+	public void test() throws InterruptedException {
+		// Codelet runs being a Memory Observer, in this case memory info does not change, so codelet wont run
+				Mind m = new Mind();
+		        MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		        MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		        MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		        MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		        MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		        MemoryContainer m6 = m.createMemoryContainer("C1");
+		        MemoryContainer m7 = m.createMemoryContainer("C2");
+		        TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		        mComplex.complextest = new TestComplexMemoryObjectInfo();
+		        for (int i=0;i<3;i++)
+		       	 mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		        MemoryObject mo = new MemoryObject();
+		        mo.setType("TestObject");
+		        mo.setI(mComplex);
+		        m7.setI(0.55, 0.23);
+		        m6.setI(0.33, 0.22);
+		        m6.setI(0.12, 0.13);
+		        m6.setI(m7);
+		        Codelet c = new TestCodelet("Codelet 1");
+		        c.setLoop(false);
+		        c.addInput(m1);
+		        c.addInput(m2);
+		        c.addOutput(m3);
+		        c.addOutput(m4);
+		        c.addBroadcast(m5);
+		        c.addBroadcast(mo);
+		        m.insertCodelet(c);
+		        Codelet c2 = new TestCodelet("Codelet 2");
+		        c2.setLoop(false);
+		        c2.addInput(m4);
+		        c2.addInput(m5);
+		        c2.addOutput(m6);
+		        c2.addOutput(m3);
+		        c2.addBroadcast(m5);
+		        m.insertCodelet(c2);
+		        m.start();
+		        Thread.sleep(2000);
+		        m.shutDown();
+	}
+
+}


### PR DESCRIPTION
### Why was it necessary?

In the mobile environment the codelets should run only when the memory input changes, so an observer pattern was implemented for this control.


