### PR TITLE
Moving CodeletsProfilerTest from cst-desktop to cst

### DIFF
--- a/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
+++ b/src/main/java/br/unicamp/cst/core/entities/MemoryContainer.java
@@ -55,7 +55,7 @@ public class MemoryContainer implements Memory {
         
         private volatile Memory last;
         private volatile int lasti=0;
-        private Random rand = new Random();
+        private transient Random rand = new Random();
 
 	/**
 	 * Creates a MemoryContainer.

--- a/src/test/java/br/unicamp/cst/support/CodeletsProfilerTest.java
+++ b/src/test/java/br/unicamp/cst/support/CodeletsProfilerTest.java
@@ -1,0 +1,401 @@
+/***********************************************************************************************
+ * Copyright (c) 2012  DCA-FEEC-UNICAMP
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v3
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Contributors:
+ * K. Raizer, A. L. O. Paraense, E. M. Froes, R. R. Gudwin - initial API and implementation
+ ***********************************************************************************************/
+package br.unicamp.cst.support;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+
+import br.unicamp.cst.core.entities.Codelet;
+import br.unicamp.cst.core.entities.MemoryContainer;
+import br.unicamp.cst.core.entities.MemoryObject;
+import br.unicamp.cst.core.entities.Mind;
+import br.unicamp.cst.support.CodeletsProfiler.FileFormat;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+//import br.unicamp.cst.util.CodeletsProfiler.CodeletTrack;
+//import br.unicamp.cst.util.CodeletsProfiler.FileFormat;
+
+public class CodeletsProfilerTest {
+      
+     private static String filePath = "profile/";
+     private String fileNameCSV_1 = "file_in_csv_1.txt";
+     private String fileNameJSON_1 = "file_in_json_1.txt";
+     private String fileNameJSON_2 = "file_in_json_2.txt";
+     private final static String comma = ",";
+     private final static String csvSeparator = ";";
+     
+
+	@BeforeAll
+	public static void beforeAllTestMethods() {
+	}
+
+	@AfterAll
+	public static void afterAllTestMethods() {
+		try  
+		{         
+			File f= new File(filePath);      
+			f.delete(); 
+		}  
+		catch(Exception e)  {  
+			e.printStackTrace();  
+		}  
+
+	}
+
+	private List<List<String>> readCSVFile(String fileName) {
+		BufferedReader br = null;
+		List<List<String>> records = new ArrayList<>();
+		try {
+			br = new BufferedReader(new FileReader(fileName));
+			String line = br.readLine();
+
+			while ((line = br.readLine()) != null) {
+		        String[] values = line.split(comma);
+		        records.add(Arrays.asList(values));
+		    }
+		} catch (Exception e) {
+
+			e.printStackTrace();
+
+		} finally {
+			try {
+				br.close();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return records;
+	}
+	
+	private JsonArray readJSONFile(String fileName) {
+		JsonArray data = null;
+		BufferedReader br = null;
+        try
+        {
+        	br = new BufferedReader(new FileReader(fileName));
+    		JsonParser parser = new JsonParser();
+    		data = parser.parse(br).getAsJsonArray();
+ 
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+			try {
+				br.close();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+        return data;
+	}
+	
+	private void deleteFile(String fileName) {
+		try  
+		{         
+			File f= new File(fileName);      
+			f.delete(); 
+		}  
+		catch(Exception e)  {  
+			e.printStackTrace();  
+		}    
+	}
+	
+	private void assertsCodeletNameInCSVFile(List<List<String>> textCSV, String codeletName) {
+		  for (List<String> item : textCSV) {
+	        	 for (String line : item) {
+	        		 String[] values = line.split(csvSeparator);
+	        		 assertEquals(values[2], codeletName);
+	        	 }
+	        	 
+	         }
+	}
+	
+	private void assertsCodeletNameInJSONFile(JsonArray codeletsTrack, String codeletName) {
+        for (int i = 0; i < (codeletsTrack.size() - 1); i++) {
+       	 assertEquals(codeletsTrack.get(i).getAsJsonObject().get("codeletName").getAsString(), codeletName);
+        }
+	}
+
+	@Test
+    public void testCodeletsProfiler() throws InterruptedException {
+		
+    	 Mind m = new Mind();
+         MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+         MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+         MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+         MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+         MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+         MemoryContainer m6 = m.createMemoryContainer("C1");
+         MemoryContainer m7 = m.createMemoryContainer("C2");
+         TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+         mComplex.complextest = new TestComplexMemoryObjectInfo();
+         for (int i=0;i<3;i++)
+        	 mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+         MemoryObject mo = new MemoryObject();
+         mo.setType("TestObject");
+         mo.setI(mComplex);
+         m7.setI(0.55, 0.23);
+         m6.setI(0.33, 0.22);
+         m6.setI(0.12, 0.13);
+         m6.setI(m7);
+         Codelet c = new TestCodelet("Codelet 1");
+         c.addInput(m1);
+         c.addInput(m2);
+         c.addOutput(m3);
+         c.addOutput(m4);
+         c.addBroadcast(m5);
+         c.addBroadcast(mo);
+         c.setCodeletProfiler(filePath, fileNameCSV_1, "Mind 1", 10, null, FileFormat.CSV);
+         m.insertCodelet(c);
+         Codelet c2 = new TestCodelet("Codelet 2");
+         c2.addInput(m4);
+         c2.addInput(m5);
+         c2.addOutput(m6);
+         c2.addOutput(m3);
+         c2.addBroadcast(m5);
+         c2.setCodeletProfiler(filePath, fileNameJSON_1, "Mind 1", 10, null, FileFormat.JSON);
+         m.insertCodelet(c2);
+         m.start();
+         Thread.sleep(2000);
+         m.shutDown();
+         
+         List<List<String>> textCSV = readCSVFile(filePath+fileNameCSV_1);         
+         assertsCodeletNameInCSVFile(textCSV, "Codelet 1");
+         
+         deleteFile(filePath+fileNameCSV_1);
+         
+ 		 JsonArray codeletsTrack = readJSONFile(filePath+fileNameJSON_1);
+         assertsCodeletNameInJSONFile(codeletsTrack, "Codelet 2");
+
+         deleteFile(filePath+fileNameJSON_1);
+    	
+    }
+
+	@Test
+	public void testCodeletsProfiler2() throws InterruptedException {
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		Codelet c = new TestCodelet("Codelet 1");
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		c.setCodeletProfiler(filePath, fileNameJSON_1, "Mind 1", null, (long) 1000, FileFormat.JSON);
+		m.insertCodelet(c);
+		Codelet c2 = new TestCodelet("Codelet 2");
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		c2.setCodeletProfiler(filePath, fileNameJSON_2, "Mind 1", null, (long) 1000, FileFormat.JSON);
+		m.insertCodelet(c2);
+		m.start();
+		Thread.sleep(2000);
+		m.shutDown();
+		
+		JsonArray codeletsTrack1 = readJSONFile(filePath+fileNameJSON_1);
+        assertsCodeletNameInJSONFile(codeletsTrack1, "Codelet 1");
+
+        deleteFile(filePath+fileNameJSON_1);
+        
+		JsonArray codeletsTrack2 = readJSONFile(filePath+fileNameJSON_2);
+        assertsCodeletNameInJSONFile(codeletsTrack2, "Codelet 2");
+
+        deleteFile(filePath+fileNameJSON_2);
+
+	}
+
+	@Test
+	public void testCodeletsProfiler3() throws InterruptedException {
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		Codelet c = new TestCodelet("Codelet 1");
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		m.insertCodelet(c);
+		Codelet c2 = new TestCodelet("Codelet 2");
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		c2.setCodeletProfiler(filePath, fileNameCSV_1, "Mind 1", null, (long) 1000, FileFormat.CSV);
+		m.insertCodelet(c2);
+		m.start();
+		Thread.sleep(2000);
+		m.shutDown();
+		
+		List<List<String>> textCSV = readCSVFile(filePath+fileNameCSV_1);         
+        assertsCodeletNameInCSVFile(textCSV, "Codelet 2");
+         
+        deleteFile(filePath+fileNameCSV_1);
+
+	}
+
+	@Test
+	public void testCodeletsProfiler4() throws InterruptedException {
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		Codelet c = new TestCodelet("Codelet 1");
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		c.setCodeletProfiler(filePath, fileNameJSON_1, "Mind 1", 5, null, FileFormat.JSON);
+		m.insertCodelet(c);
+		Codelet c2 = new TestCodelet("Codelet 2");
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		c2.setCodeletProfiler(filePath, fileNameCSV_1, "Mind 1", 5, (long) 1000, FileFormat.CSV);
+		m.insertCodelet(c2);
+		m.start();
+		Thread.sleep(2000);
+		m.shutDown();
+		
+		JsonArray codeletsTrack = readJSONFile(filePath+fileNameJSON_1);
+	    assertsCodeletNameInJSONFile(codeletsTrack, "Codelet 1");
+
+	    deleteFile(filePath+fileNameJSON_1);
+		
+		List<List<String>> textCSV = readCSVFile(filePath+fileNameCSV_1);         
+        assertsCodeletNameInCSVFile(textCSV, "Codelet 2");
+        
+        deleteFile(filePath+fileNameCSV_1);
+        
+	}
+
+	@Test
+	public void testCodeletsProfiler5() throws InterruptedException {
+		Mind m = new Mind();
+		MemoryObject m1 = m.createMemoryObject("M1", 0.12);
+		MemoryObject m2 = m.createMemoryObject("M2", 0.32);
+		MemoryObject m3 = m.createMemoryObject("M3", 0.44);
+		MemoryObject m4 = m.createMemoryObject("M4", 0.52);
+		MemoryObject m5 = m.createMemoryObject("M5", 0.12);
+		MemoryContainer m6 = m.createMemoryContainer("C1");
+		MemoryContainer m7 = m.createMemoryContainer("C2");
+		TestComplexMemoryObjectInfo mComplex = new TestComplexMemoryObjectInfo();
+		mComplex.complextest = new TestComplexMemoryObjectInfo();
+		for (int i = 0; i < 3; i++)
+			mComplex.complextestarray[i] = new TestComplexMemoryObjectInfo();
+		MemoryObject mo = new MemoryObject();
+		mo.setType("TestObject");
+		mo.setI(mComplex);
+		m7.setI(0.55, 0.23);
+		m6.setI(0.33, 0.22);
+		m6.setI(0.12, 0.13);
+		m6.setI(m7);
+		Codelet c = new TestCodelet("Codelet 1");
+		c.addInput(m1);
+		c.addInput(m2);
+		c.addOutput(m3);
+		c.addOutput(m4);
+		c.addBroadcast(m5);
+		c.addBroadcast(mo);
+		c.setCodeletProfiler(filePath, fileNameJSON_1, "Mind 1", null, null, FileFormat.JSON);
+		m.insertCodelet(c);
+		Codelet c2 = new TestCodelet("Codelet 2");
+		c2.addInput(m4);
+		c2.addInput(m5);
+		c2.addOutput(m6);
+		c2.addOutput(m3);
+		c2.addBroadcast(m5);
+		c2.setCodeletProfiler(filePath, fileNameCSV_1, "Mind 1", null, null, FileFormat.CSV);
+		m.insertCodelet(c2);
+		m.start();
+		Thread.sleep(2000);
+		m.shutDown();
+		
+		JsonArray codeletsTrack = readJSONFile(filePath+fileNameJSON_1);
+	    assertsCodeletNameInJSONFile(codeletsTrack, "Codelet 1");
+
+	    deleteFile(filePath+fileNameJSON_1);
+		
+		List<List<String>> textCSV = readCSVFile(filePath+fileNameCSV_1);         
+        assertsCodeletNameInCSVFile(textCSV, "Codelet 2");
+        
+        deleteFile(filePath+fileNameCSV_1);
+
+	}
+
+}

--- a/src/test/java/br/unicamp/cst/support/TestCodelet.java
+++ b/src/test/java/br/unicamp/cst/support/TestCodelet.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************
+ * Copyright (c) 2012  DCA-FEEC-UNICAMP
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v3
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Contributors:
+ * K. Raizer, A. L. O. Paraense, E. M. Froes, R. R. Gudwin - initial API and implementation
+ ***********************************************************************************************/
+package br.unicamp.cst.support;
+
+import br.unicamp.cst.core.entities.Codelet;
+
+/**
+ * 
+ * @author gudwin
+ *
+ */
+public class TestCodelet extends Codelet{
+
+	public TestCodelet(String name) {
+		setName(name);
+	}
+
+	@Override
+	public void accessMemoryObjects() {
+		
+	}
+
+	@Override
+	public void calculateActivation() {
+		
+	}
+
+	@Override
+	public void proc() {
+		
+	}
+
+}

--- a/src/test/java/br/unicamp/cst/support/TestComplexMemoryObjectInfo.java
+++ b/src/test/java/br/unicamp/cst/support/TestComplexMemoryObjectInfo.java
@@ -1,0 +1,119 @@
+/***********************************************************************************************
+ * Copyright (c) 2012  DCA-FEEC-UNICAMP
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v3
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Contributors:
+ * K. Raizer, A. L. O. Paraense, E. M. Froes, R. R. Gudwin - initial API and implementation
+ * **********************************************************************************************/
+package br.unicamp.cst.support;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ *
+ * @author rgudwin
+ */
+public class TestComplexMemoryObjectInfo {
+    public long testlong;
+    public int testint;
+    public float testfloat;
+    public double testdouble;
+    public byte testbyte;
+    public short testshort;
+    public boolean testboolean;
+    public String testString="Test";
+    public Date testdate=new Date();
+    public int[] testintarray = new int[10];
+    public long[] testlongarray = new long[10];
+    public float[] testfloatarray = new float[10];
+    public double[] testdoublearray = new double[10];
+    public short[] testshortarray = new short[10];
+    public byte[] testbytearray = new byte[10];
+    public boolean[] testbooleanarray = new boolean[10];
+    public TestComplexMemoryObjectInfo complextest;
+    public TestComplexMemoryObjectInfo[] complextestarray = new TestComplexMemoryObjectInfo[3];
+    public List<TestComplexMemoryObjectInfo> complextestlist = new ArrayList<>();
+    public List<Double> complextestlist2 = new ArrayList<>();
+    
+    public TestComplexMemoryObjectInfo() {
+        complextestlist2.add(3.14);
+        complextestlist2.add(0.12);
+    } 
+    
+    
+    public String toString() {
+        return(testString);
+    }
+    
+    public int equals(TestComplexMemoryObjectInfo other) {
+        int ret = 0;
+        if (testlong != other.testlong ||
+            testint != other.testint ||
+            testfloat != other.testfloat ||
+            testdouble != other.testdouble ||
+            testbyte != other.testbyte ||
+            testshort != other.testshort ||
+            testboolean != other.testboolean)  ret = 1;
+        if (!testString.equals(other.testString)) ret = 2;
+        if (!testdate.equals(other.testdate)) ret = 3;
+        if (testintarray.length != other.testintarray.length) 
+            ret = 4;
+        else {            
+            for (int i=0;i<testintarray.length;i++) 
+                if (testintarray[i] != other.testintarray[i]) ret = 5;
+        }
+        if (testlongarray.length != other.testlongarray.length) 
+            ret = 6;
+        else {            
+            for (int i=0;i<testlongarray.length;i++) 
+                if (testlongarray[i] != other.testlongarray[i]) ret = 7;
+        }
+        if (testfloatarray.length != other.testfloatarray.length) 
+            ret = 8;
+        else {            
+            for (int i=0;i<testfloatarray.length;i++) 
+                if (testfloatarray[i] != other.testfloatarray[i]) ret = 9;
+        }
+        if (testdoublearray.length != other.testdoublearray.length) 
+            ret = 10;
+        else {            
+            for (int i=0;i<testdoublearray.length;i++) 
+                if (testdoublearray[i] != other.testdoublearray[i]) ret = 11;
+        }
+        if (complextest == null && other.complextest != null) ret = 12;
+        if (complextest != null && other.complextest == null) ret = 13;
+        if (complextest != null && other.complextest != null)
+            if (complextest.equals(other.complextest) != 0) ret = 14;
+        if (complextestarray.length != other.complextestarray.length) ret = 15;
+        else {            
+            for (int i=0;i<complextestarray.length;i++) {
+                if (complextestarray[i] == null && other.complextestarray[i] != null) ret = 16;
+                if (complextestarray[i] != null && other.complextestarray[i] == null) ret = 17;
+                if (complextestarray[i] != null && other.complextestarray[i] != null)
+                    if (complextestarray[i].equals(other.complextestarray[i]) != 0) ret = 18;
+            }    
+        }
+        if (complextestlist == null && other.complextestlist != null) ret = 19;
+        if (complextestlist != null && other.complextestlist == null) ret = 20;
+        if (complextestlist != null && complextestlist != null) {
+            if (complextestlist.size() != other.complextestlist.size()) ret = 21;
+            for (int i=0;i<complextestlist.size();i++) {
+                if (complextestlist.get(i).equals(other.complextestlist.get(i)) != 0) ret = 22;
+            }
+        }
+        if (complextestlist2 == null && other.complextestlist2 != null) ret = 19;
+        if (complextestlist2 != null && other.complextestlist2 == null) ret = 20;
+        if (complextestlist2 != null && complextestlist2 != null) {
+            if (complextestlist2.size() != other.complextestlist2.size()) ret = 21;
+            for (int i=0;i<complextestlist2.size();i++) {
+                if ((double)complextestlist2.get(i) != (double)other.complextestlist2.get(i)) ret = 22;
+            }
+        }
+        return(ret);
+    }
+}


### PR DESCRIPTION
### Why was it necessary?

Even thought CST had the class CodeletsProfiler, the CodeletsProfilerTest was still in cst-desktop. This branch returns the CodeletsProfiler test and its necessary classes to CST

### How was it done?

Moving the classes from CST-Desktop to CST

### Implementation details

This is auto-explainable

### How to test?

Just run junits-tests

### Future works

Nothing to declare
