### PR TITLE
Update java-ci.yml workflow file

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -12,10 +12,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+        contents: write
+        pages: write
+        id-token: write
     strategy:
       matrix:
-        java: [ '8', '11', '17']
+        java: [ '8', '11', '17', '21', '25']
     name: JDK ${{ matrix.Java }} build
 
     services:
@@ -34,17 +38,15 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v5.0.0
       - name: Set up Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: gradle
-      - name: Before Script
-        run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter && ./cc-test-reporter before-build
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.3.0
+        uses: gradle/actions/wrapper-validation@v4.4.2
       - name:  Build with Gradle headless
         uses: coactions/setup-xvfb@v1.0.1
         with:
@@ -56,9 +58,8 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
       - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: 430594ee361ff2e93ebf0a942f639b8092c6f17b7c5098f9c75abc404311dfc7
-          JACOCO_SOURCE_PATH: "${{github.workspace}}/src/main/java"
+        uses: qltysh/qlty-action/coverage@v2
         with:
-          coverageLocations: ${{github.workspace}}/build/reports/jacoco/test/jacocoTestReport.xml:jacoco
+          oidc: true
+          files: ${{github.workspace}}/build/reports/jacoco/test/jacocoTestReport.xml
+          add-prefix: src/main/java/

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -19,7 +19,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21', '25']
+        java: [ '8', '11', '17', '21', '24']
     name: JDK ${{ matrix.Java }} build
 
     services:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Why was it necessary?

This update was necessary because ColdClimate became obsolete, and this broke the workflow

### How was it done?

We changed the references to coldclimate to qlty, the new tool available

### Implementation details

Small changes to the java-ci.yml file 


### How to test?

Just push some code and check if the workflow works

### Future works

As soon as new updates to the workflow are available
